### PR TITLE
Fix: application.yml 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,6 @@ springdoc:
     use-root-path: true
     urls:
       - name: Ingredient Service API
-        url: http://${GATEWAY_IP}:8080/api/ingredients/v3/api-docs
+        url: http://yum-ingredient-server-container:8080/api/ingredients/v3/api-docs
       - name: Recipe Service API
-        url: http://${GATEWAY_IP}:8080/api/recipes/v3/api-docs
+        url: http://yum-recipe-server-container:8080/api/recipes/v3/api-docs


### PR DESCRIPTION
서버 Url이 변경되어 기존의 api gateway 라우팅 url이 변경되었습니다.

```yml
springdoc:
  swagger-ui:
    use-root-path: true
    urls:
      - name: Ingredient Service API
        url: http://yum-ingredient-server-container:8080/api/ingredients/v3/api-docs
      - name: Recipe Service API
        url: http://yum-recipe-server-container:8080/api/recipes/v3/api-docs
```

따라서, springdoc의 url이 변경되었습니다.