### PR TITLE
Fix: springdoc 라우팅 롤백

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,6 @@ springdoc:
     use-root-path: true
     urls:
       - name: Ingredient Service API
-        url: http://yum-ingredient-server-container:8080/api/ingredients/v3/api-docs
+        url: http://${GATEWAY_DNS}:8080/api/ingredients/v3/api-docs
       - name: Recipe Service API
-        url: http://yum-recipe-server-container:8080/api/recipes/v3/api-docs
+        url: http://${GATEWAY_DNS}:8080/api/recipes/v3/api-docs


### PR DESCRIPTION
CORS 이슈 해결을 잠시 막기 위하여 환경변수로 DNS를 통합합니다.

```yml
springdoc:
  swagger-ui:
    use-root-path: true
    urls:
      - name: Ingredient Service API
        url: http://${GATEWAY_DNS}:8080/api/ingredients/v3/api-docs
      - name: Recipe Service API
        url: http://${GATEWAY_DNS}:8080/api/recipes/v3/api-docs
```