### PR TITLE
Feat: 인증 서버 게이트웨이 정보 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,13 +10,18 @@ spring:
     gateway:
       routes:
         - id: yum-ingredient-server
-          uri: http://yum-ingredient-server-container:8080
+          uri: http://${YUM_INGREDIENT_SERVER}:8080
           predicates:
             - Path=/api/ingredients/**
         - id: yum-recipe-server
-          uri: http://yum-recipe-server-container:8080
+          uri: http://${YUM_RECIPE_SERVER}:8080
           predicates:
             - Path=/api/recipes/**
+        - id: yum-auth-server
+          uri: http://${YUM_AUTH_SERVER}:8080
+          predicates:
+            - Path=/api/signup/**
+            - Path=/api/login/**
 
 springdoc:
   swagger-ui:
@@ -26,3 +31,5 @@ springdoc:
         url: http://${GATEWAY_DNS}:8080/api/ingredients/v3/api-docs
       - name: Recipe Service API
         url: http://${GATEWAY_DNS}:8080/api/recipes/v3/api-docs
+      - name: Auth Service API
+        url: http://${GATEWAY_DNS}:8080/api/signup/v3/api-docs


### PR DESCRIPTION
인증 서버가 추가됨에 따라서 스웨거와 인증 서버의 게이트웨이 설정이 추가되었습니다.

```yml
  cloud:
    gateway:
      routes:
        - id: yum-ingredient-server
          uri: http://${YUM_INGREDIENT_SERVER}:8080
          predicates:
            - Path=/api/ingredients/**
        - id: yum-recipe-server
          uri: http://${YUM_RECIPE_SERVER}:8080
          predicates:
            - Path=/api/recipes/**
         # 추가됨
        - id: yum-auth-server
          uri: http://${YUM_AUTH_SERVER}:8080
          predicates:
            - Path=/api/signup/**
            - Path=/api/login/**


springdoc:
  swagger-ui:
    use-root-path: true
    urls:
      - name: Ingredient Service API
        url: http://${GATEWAY_DNS}:8080/api/ingredients/v3/api-docs
      - name: Recipe Service API
        url: http://${GATEWAY_DNS}:8080/api/recipes/v3/api-docs
         # 추가됨
      - name: Auth Service API
        url: http://${GATEWAY_DNS}:8080/api/signup/v3/api-docs
```